### PR TITLE
Fix parameter order in initializing SingleGrid object

### DIFF
--- a/examples/pd_grid/pd_grid/model.py
+++ b/examples/pd_grid/pd_grid/model.py
@@ -31,7 +31,7 @@ class PdGrid(Model):
                            Determines the agent activation regime.
             payoffs: (optional) Dictionary of (move, neighbor_move) payoffs.
         '''
-        self.grid = SingleGrid(height, width, torus=True)
+        self.grid = SingleGrid(width, height, torus=True)
         self.schedule_type = schedule_type
         self.schedule = self.schedule_types[self.schedule_type](self)
 

--- a/examples/schelling/model.py
+++ b/examples/schelling/model.py
@@ -50,7 +50,7 @@ class Schelling(Model):
         self.homophily = homophily
 
         self.schedule = RandomActivation(self)
-        self.grid = SingleGrid(height, width, torus=True)
+        self.grid = SingleGrid(width, height, torus=True)
 
         self.happy = 0
         self.datacollector = DataCollector(


### PR DESCRIPTION
Parameter order should be width, height, torus according to https://mesa.readthedocs.io/en/master/apis/space.html